### PR TITLE
fix(docker): clean arm64  platform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ name: Build and Push
 #    branches: main
 #    types: completed
 
-
 on:
   push:
     branches:
@@ -72,7 +71,7 @@ jobs:
           cache-to: type=gha,mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           build-args: |
             BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
             GIT_HASH=${{ steps.vars.outputs.git-hash }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,35 @@
+FROM python:3.12
 
-FROM	python:3.12
-ADD	./src	/src
-COPY	./requirements.txt	/src/requirements.txt
-RUN	pip install -r /src/requirements.txt
-RUN	adduser --system --no-create-home controller
-RUN	chmod +x /src/entrypoint.sh
-USER	controller
-CMD	["/src/entrypoint.sh"]
-LABEL	org.opencontainers.image.version=${GIT_HASH}
-LABEL	org.opencontainers.image.created=${BUILD_DATE}
-LABEL	org.opencontainers.image.documentation="https://github.com/Ramblurr/crunchy-userinit-controller"
-LABEL	org.opencontainers.image.source="https://github.com/Ramblurr/crunchy-userinit-controller"
-LABEL	org.opencontainers.image.vendor="@ramblurr"
+# Define build arguments to fix the undefined variable warnings
+ARG GIT_HASH=unknown
+ARG BUILD_DATE=unknown
+
+# Add cross-compilation support
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+# Copy source code and requirements
+COPY ./src /src
+COPY ./requirements.txt /src/requirements.txt
+
+# Install Python dependencies
+RUN pip install -r /src/requirements.txt
+
+# Create user and set permissions
+RUN adduser --system --no-create-home controller
+RUN chmod +x /src/entrypoint.sh
+
+# Switch to non-root user
+USER controller
+
+# Set the entrypoint
+CMD ["/src/entrypoint.sh"]
+
+# Add metadata labels
+LABEL org.opencontainers.image.version=${GIT_HASH}
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.documentation="https://github.com/Ramblurr/crunchy-userinit-controller"
+LABEL org.opencontainers.image.source="https://github.com/Ramblurr/crunchy-userinit-controller"
+LABEL org.opencontainers.image.vendor="@ramblurr"


### PR DESCRIPTION
Closed #2 

meanwhile i use this image https://hub.docker.com/r/drummyfloyd/crunchy-userinit-controller
 ```yaml

apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

resources:
  - ./clusters
  - ./css

commonAnnotations:
  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

helmCharts:
  - name: crunchy-userinit-controller
    repo: https://ramblurr.github.io/crunchy-userinit-controller
    version: 0.0.4
    releaseName: crunchy-userinit-controller
    namespace: databases
    valuesInline:
      image:
        # BUG: until https://github.com/Ramblurr/crunchy-userinit-controller/issues/2
        repository: drummyfloyd/crunchy-userinit-controller
        tag: 0.0.4

```